### PR TITLE
Explicitly bind to 0.0.0.0 because of change in rails 4.2

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rackup -p $PORT
+web: bundle exec rackup -p $PORT -o 0.0.0.0


### PR DESCRIPTION
cf. section 3.3 of http://guides.rubyonrails.org/4_2_release_notes.html